### PR TITLE
Issue59 find editor handle through child window enumeration

### DIFF
--- a/sample/ConsoleDemo/Program.cs
+++ b/sample/ConsoleDemo/Program.cs
@@ -14,9 +14,9 @@
 //
 #endregion
 
+using Serilog;
 using System;
 using System.Threading;
-using Serilog;
 
 namespace ConsoleDemo
 {
@@ -33,15 +33,23 @@ namespace ConsoleDemo
 
             try
             {
-                Console.WriteLine("Open a `notepad.exe` instance and press <enter> to continue...");
-                Console.ReadLine();
+                //Console.WriteLine("Open a `notepad.exe` instance and press <enter> to continue...");
+                //Console.ReadLine();
 
                 Console.WriteLine("Writing messages to the most recent Notepad you opened...");
 
                 Log.Debug("Getting started");
 
-                Log.Information("Hello {Name} from thread {ThreadId}", Environment.GetEnvironmentVariable("USERNAME"),
-                    Thread.CurrentThread.ManagedThreadId);
+                var startTime = DateTime.Now;
+
+                while (DateTime.Now - startTime < TimeSpan.FromMinutes(1))
+                {
+
+                    Log.Information("Hello {Name} from thread {ThreadId}", Environment.GetEnvironmentVariable("USERNAME"),
+                        Thread.CurrentThread.ManagedThreadId);
+
+                    Thread.Sleep(1000);
+                }
 
                 Log.Warning("No coins remain at position {@Position}", new { Lat = 25, Long = 134 });
 

--- a/src/Serilog.Sinks.Notepad/Sinks/Notepad/Interop/NotepadTextWriter.cs
+++ b/src/Serilog.Sinks.Notepad/Sinks/Notepad/Interop/NotepadTextWriter.cs
@@ -57,7 +57,10 @@ namespace Serilog.Sinks.Notepad.Interop
                     // No instances of Notepad found... Nothing to do
                     return;
                 }
+            }
 
+            if (_currentNotepadEditorHandle == IntPtr.Zero)
+            {
                 var notepadWindowHandle = currentNotepadProcess.MainWindowHandle;
 
                 var notepadEditorHandle = FindNotepadEditorHandle(notepadWindowHandle);

--- a/src/Serilog.Sinks.Notepad/Sinks/Notepad/Interop/User32.cs
+++ b/src/Serilog.Sinks.Notepad/Sinks/Notepad/Interop/User32.cs
@@ -35,5 +35,16 @@ namespace Serilog.Sinks.Notepad.Interop
 
         [DllImport("User32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
+
+
+        [DllImport("user32.dll")]
+        public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+
+        // Needed for EnumChildWindows for registering a call back function.
+        public delegate bool Win32Callback(IntPtr hwnd, IntPtr lParam);
+
+        [DllImport("user32.Dll")]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool EnumChildWindows(IntPtr parentHandle, Win32Callback callback, IntPtr lParam);
     }
 }

--- a/src/Serilog.Sinks.Notepad/Sinks/Notepad/Interop/User32.cs
+++ b/src/Serilog.Sinks.Notepad/Sinks/Notepad/Interop/User32.cs
@@ -37,14 +37,15 @@ namespace Serilog.Sinks.Notepad.Interop
         public static extern IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
 
 
-        [DllImport("user32.dll")]
-        public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
-
         // Needed for EnumChildWindows for registering a call back function.
         public delegate bool Win32Callback(IntPtr hwnd, IntPtr lParam);
 
-        [DllImport("user32.Dll")]
+        [DllImport("user32.Dll", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
         public static extern bool EnumChildWindows(IntPtr parentHandle, Win32Callback callback, IntPtr lParam);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern int GetClassName(IntPtr hWnd, System.Text.StringBuilder lpClassName, int nMaxCount);
+
     }
 }


### PR DESCRIPTION
- Added methods to User32 class to allow for enumerating child windows.
- When trying to find the editor handle in Windows 11 Notepad, and FindWindowEx does not find it, an attempt is now made to enumerate the child windows of the notepadProcess.MainWindowHandle and returning the first found instance of RichEditD2DPT class. This is the last opened document in Notepad.